### PR TITLE
fix: add React deduplication to Vite resolve config

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -26,7 +26,7 @@ export default function starlightMegaMenu(config: MegaMenuConfig): StarlightPlug
           addIntegration(react());
         }
 
-        // 2. Add Vite virtual module via Astro integration
+        // 2. Add Vite virtual module + React deduplication via Astro integration
         addIntegration({
           name: 'starlight-mega-menu-integration',
           hooks: {
@@ -34,6 +34,9 @@ export default function starlightMegaMenu(config: MegaMenuConfig): StarlightPlug
               updateAstroConfig({
                 vite: {
                   plugins: [vitePluginMegaMenuConfig(config)],
+                  resolve: {
+                    dedupe: ['react', 'react-dom', 'react/jsx-runtime', 'react/jsx-dev-runtime'],
+                  },
                 },
               });
             },


### PR DESCRIPTION
## Summary
- Adds `resolve.dedupe` for React packages in the Vite configuration to prevent duplicate React instances when Radix UI resolves its own copy
- Fixes "Invalid hook call" / `useState is null` errors during SSR

Closes #1

## Test plan
- [x] E2E verified: Desktop mega-menu renders correctly
- [x] E2E verified: Mobile hamburger menu works (open, close, escape, accordion, link navigation)
- [x] E2E verified: Theme toggle dark/light mode works with dropdown panels
- [x] `astro build` completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)