### PR TITLE
feat: add concurrency settings to workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,10 @@ permissions:
   pull-requests: write
   id-token: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   release:
     name: Semantic Release


### PR DESCRIPTION
## Summary

Add `concurrency` blocks to repo-specific workflows to prevent duplicate runs and save runner minutes.

Closes #37

## Test plan

- [ ] CI checks pass
- [ ] Workflow runs show concurrency group in metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)